### PR TITLE
#68: Наполнение score в реплае для PUT /wallet

### DIFF
--- a/node/app.py
+++ b/node/app.py
@@ -7,6 +7,7 @@
 ''' WEB интерфейс узла '''
 
 from flask import Flask, jsonify, request
+from flask_api import status
 from werkzeug.exceptions import NotAcceptable, BadRequest
 from zold.score import StrongestScore, NextScore, ScoreHash, ScoreValid
 from node.db import DB
@@ -115,8 +116,13 @@ def api_put_wallet(wallet_id):
 		'version': '0.0.0',
 		'protocol': '1',
 		'id': wallet_id,
+		'score': StrongestScore(AtLeastOneDbScores(DbScores(), APP.config)).json()
 	})
-	resp.status_code = 202
+	# @todo #68 Сервер должен возвращать HTTP_ACCEPTED, в соответствии с WP.
+	#  Но текущий клиент рассчитывает, что сервер отвечает кодом HTTP_OK.
+	#  Достоточно сложно будет перейти с одного на другой.
+	#  Клиент должен будет поддерживать оба.
+	resp.status_code = status.HTTP_200_OK
 	resp.headers['X-Zold-Version'] = '0.0.0'
 	return resp
 

--- a/node/app.py
+++ b/node/app.py
@@ -117,7 +117,7 @@ def api_put_wallet(wallet_id):
 		'protocol': '1',
 		'id': wallet_id,
 		'score': StrongestScore(AtLeastOneDbScores(DbScores(), APP.config)).json()
-	})
+	}
 	# @todo #68 Сервер должен возвращать HTTP_ACCEPTED, в соответствии с WP.
 	#  Но текущий клиент рассчитывает, что сервер отвечает кодом HTTP_200_OK.
 	#  Достоточно сложно будет перейти с одного на другой.

--- a/node/config.py
+++ b/node/config.py
@@ -7,9 +7,9 @@
 ''' Конфигурация узла '''
 
 HOST = 'localhost'
-PORT = 777
+PORT = 8000
 WALLET = '1234567887654321'
-PUBLIC_KEY = 'Replace this string to production public key'
+PUBLIC_KEY = 'Replacethisstringtoproductionpublickey'
 
 SQLALCHEMY_DATABASE_URI = 'sqlite:///test.db'
 SQLALCHEMY_TRACK_MODIFICATIONS = True

--- a/node/score.py
+++ b/node/score.py
@@ -35,6 +35,16 @@ class DbScore:
 			for s in Suffix.query.filter(Suffix.score_id == self.record.id).all()
 		]
 
+	def __str__(self):
+		return ' '.join(
+			[
+				str(DatetimeTime(self.record.time)),
+				self.record.host,
+				str(self.record.port),
+				self.record.invoice,
+			] + self.suffixes()
+		)
+
 	def json(self):
 		''' Унифицированное json представление '''
 		return {
@@ -93,7 +103,7 @@ class AtLeastOneDbScores:
 			score = Score(
 				self.config['HOST'],
 				self.config['PORT'],
-				' '.join((
+				''.join((
 					self.config['PUBLIC_KEY'][key_pos:key_pos + 8],
 					'@',
 					self.config['WALLET']

--- a/test/node/test_put_wallet.py
+++ b/test/node/test_put_wallet.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2018 Andrey Valyaev <dron.valyaev@gmail.com>
+# Copyright (c) 2018 Alexey Tsurkan
+#
+# This software may be modified and distributed under the terms
+# of the MIT license.  See the LICENSE file for details.
+
+''' Тестирование Работы с кошельками '''
+
+from node.app import APP
+from zold.score import JsonScore, ScoreValid
+
+
+class TestPutWallet:
+	''' Тестируем PUT /wallet/<id> '''
+	EMPTY_WALLET = '\n'.join((
+		'zold',
+		'1',
+		'cb91e8b5b4b66866'
+		''.join((
+			'MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA2Z999vmvkavYi4Uh7uV2mPPKYMAKS',
+			'rnbO2Iwi97PlXOACocXYCaRaoWHCrbtHuKR3dtjrU9hVygvl0UlmeMnvilOLobMMIBrr+TTjp',
+			'bztHSKjXdhT7cxxWLMG5hqcaO9E6HxCpKXn/DbCK0il6nhcZGz/zciCa/vpo1WB05TWpIMcaR',
+			'ouI/uKLlQsglegD9OB3aiXuYWnYvJBOZIzuCf3/M/KljH6/MfopR6LlxbZgAWLEbLxn7r9OHE',
+			'eD+/2PX3DgD4OOtvvM9HSnvcoXNgL2MHyo6TzKmNE+BamwO5WfB8Wb71CED9k/qa9YOSMKPJH',
+			'MGkIEoFqF7G7hA+vsCbLp1MWtv0100GM/Vgxy5Ae/7g6EmYEUOgx7mIzWyKorHayWq5TBchFm',
+			'qGB6aTkMbhKKyfIl1djBe3TXAqXVq1nncuz25ZxybFwKA6Z52OB4S3tAWE5qRsnBe6ppoiY9/',
+			'FuwQRS9stIBoY3hEfo58BVxjnLTbymvV8bvgLYXLgtcjjyLhzmUyzXhJpzXgORVLsQLp7NA2q',
+			'gtUBQJdpyZHbbddiwHUnwQn8/Q+of5SpwJXdJOwtY25ME6e6DW/5SxZPnhU9GhR92M/RL0dGf',
+			'hRqgWSpu85CE0peNDgjcR4qzIGKlKVrGdcVn9yqLQznuNUb0y6PCtVMn9eL6PXmB35WMzUCAw',
+			'EAAQ=='
+		))
+	))
+
+	def test_server_return_score(self):
+		''' Сервер возвращает содержимое кошелька '''
+		response = APP.test_client().put(
+			'/wallet/cb91e8b5b4b66866',
+			data=self.EMPTY_WALLET
+		)
+		assert ScoreValid(JsonScore(response.json['score']))

--- a/zold/score.py
+++ b/zold/score.py
@@ -21,6 +21,37 @@ score.expired() - устарел
 import hashlib
 
 
+# @todo #68 StringScore('<zold.score.StrongestScore object at 0x7f462d0>')
+#  считается валидным. Вероятно это происходит потому,
+#  что мы не контролируем содержимое первых 4 элементов
+class StringScore:
+	''' вьюв для Score, преедставленных в виде строки'''
+	def __init__(self, score):
+		self.score = score
+
+	def __str__(self):
+		return self.score
+
+	def json(self):
+		''' Представление в виде json '''
+		parts = self.score.split()
+		return {
+			'time': parts[0],
+			'host': parts[1],
+			'port': parts[2],
+			'invoice': parts[3],
+			'suffixes': parts[4:]
+		}
+
+	def prefix(self):
+		''' Префиксная часть '''
+		return ' '.join(self.score.split()[:4])
+
+	def suffixes(self):
+		''' Список суффиксов '''
+		return self.score.split()[4:]
+
+
 class JsonScore:
 	''' Этот Score конструируется из json '''
 	def __init__(self, json):
@@ -51,6 +82,9 @@ class StrongestScore:
 	''' Самый мощный score из списка '''
 	def __init__(self, scores):
 		self.scores = scores
+
+	def __str__(self):
+		return str(max(self.scores, key=lambda s: ScoreValue(s).value()))
 
 	def json(self):
 		''' В виде json '''
@@ -111,7 +145,6 @@ class ScoreHash:
 		return prefix
 
 
-# @todo #54 Протестировать ScoreValid
 class ScoreValid:
 	''' Вспомогательный класс транслирующийся в True, если score валиден '''
 	def __init__(self, score, strength=6):


### PR DESCRIPTION
push со стандартного клиента пока не прошел, в последний раз не понял, что ему не понравилось... Может версия?
```sh
$ zold push cb91e8b5b4b66866 
localhost:8000: no implicit conversion from nil to integer in 0s; errors=3
```
По ходу зарепортил пару багов в zold...