### PR TITLE
#95: Отключили nginx, gunicorn смотрит напрямую в сеть

### DIFF
--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -9,4 +9,3 @@
     - base
     - zold
     - gunicorn
-    - nginx

--- a/ansible/roles/gunicorn/tasks/main.yml
+++ b/ansible/roles/gunicorn/tasks/main.yml
@@ -7,18 +7,10 @@
   template:
     src: gunicorn.service.j2
     dest: /etc/systemd/system/gunicorn.service
-- name: install gunicorn socket
-  copy:
-    src: gunicorn.socket
-    dest: /etc/systemd/system/
 - name: install gunicorn tmpfile
   copy:
     src: gunicorn.conf
     dest: /etc/tmpfiles.d/
-- name: create gunicorn socket directory
-  file:
-    path: /run/gunicorn
-    state: directory
 - name: Activate gunicorn
   systemd:
     name: gunicorn
@@ -30,7 +22,6 @@
 #  Причем команда service не дает того же эффекта, что странно.
 - name: Restart gunicorn
   become: yes
-  warn: False
   shell: |
     service gunicorn stop
     service gunicorn start

--- a/ansible/roles/gunicorn/templates/gunicorn.service.j2
+++ b/ansible/roles/gunicorn/templates/gunicorn.service.j2
@@ -1,6 +1,5 @@
 [Unit]
 Description=gunicorn daemon
-Requires=gunicorn.socket
 After=network.target
 
 [Service]
@@ -9,7 +8,7 @@ User=zold
 Group=zold
 RuntimeDirectory=gunicorn
 WorkingDirectory={{project_dir}}
-ExecStart=/usr/bin/env gunicorn --access-logfile - --pythonpath {{project_dir}} --pid /run/gunicorn/pid --bind unix:/run/gunicorn/socket node.app:APP
+ExecStart=/usr/bin/env gunicorn --access-logfile - --pythonpath {{project_dir}} --pid /run/gunicorn/pid --bind 0.0.0.0:{{api_port}} node.app:APP
 ExecReload=/bin/kill -s HUP $MAINPID
 ExecStop=/bin/kill -s TERM $MAINPID
 PrivateTmp=true

--- a/ansible/roles/zold/templates/config.j2
+++ b/ansible/roles/zold/templates/config.j2
@@ -12,7 +12,7 @@ WALLET = '{{wallet}}'
 PUBLIC_KEY = '{{public_key}}'
 STRENGTH = 6
 
-ZOLD_VERSION = '0.14.39'
+ZOLD_VERSION = '0.14.40'
 ZOLD_PROTOCOL = '2'
 
 SQLALCHEMY_DATABASE_URI = 'sqlite:////usr/share/zold/zold.db'


### PR DESCRIPTION
Этот пулл реквест не нужно мержить...
Запуск gunicorn без nginx - это не очень секурно.
НО пока пусть сервак покрутится так, а это изменение нужно для того, чтобы перезаливать сервер.